### PR TITLE
properly handle C integers

### DIFF
--- a/cmd/mod_prometheus_status/module.go
+++ b/cmd/mod_prometheus_status/module.go
@@ -45,8 +45,8 @@ const (
 )
 
 //export prometheusStatusInit
-func prometheusStatusInit(metricsSocket, serverDesc *C.char, serverHostName, version *C.char, debug, userID, groupID C.int, labelNames *C.char, mpmName *C.char, socketTimeout int, timeBuckets, sizeBuckets *C.char) C.int {
-	defaultSocketTimeout = socketTimeout
+func prometheusStatusInit(metricsSocket, serverDesc *C.char, serverHostName, version *C.char, debug, userID, groupID C.int, labelNames *C.char, mpmName *C.char, socketTimeout C.int, timeBuckets, sizeBuckets *C.char) C.int {
+	defaultSocketTimeout = int(socketTimeout)
 
 	initLogging(int(debug))
 


### PR DESCRIPTION
The plugin occasionally refuses to due anything and just logs 'i/o timeouts'. Seems like sometimes the integer overflows and causes a negative timeout.