### PR TITLE
Make logging use standard error log format

### DIFF
--- a/cmd/mod_prometheus_status/logger.go
+++ b/cmd/mod_prometheus_status/logger.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// LogFormat sets the log format
-	LogFormat = `[%{Date} %{Time "15:04:05.000000"}][mod_prometheus_status][%{Severity}]%{Message}`
+	LogFormat = `[%{Time "Mon Jan 02 15:04:05.000000 2006"}] [mod_prometheus_status:%{severity}] [pid %{Pid}:tid ???] %{Message}`
 
 	// LogVerbosityDebug sets the debug log level
 	LogVerbosityDebug = 2
@@ -45,7 +45,7 @@ func initLogging(enableDebug int) {
 func logf(lvl int, format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
 	_, file, line, _ := runtime.Caller(2)
-	logmsg := fmt.Sprintf("[pid:%d][%s:%d] %s", os.Getpid(), filepath.Base(file), line, msg)
+	logmsg := fmt.Sprintf("[%s:%d] %s", filepath.Base(file), line, msg)
 	switch lvl {
 	case LogVerbosityError:
 		logger.Errorf(logmsg)


### PR DESCRIPTION
Fixes #7

It builds locally OK and I ran the tests - the centos one seemed to work ok, but the ubuntu testbox seemed to fail with  some ansible playbook issues.

With this change, the logs now look like this:

```
[Tue Nov 07 18:41:46.345110 2023] [mod_prometheus_status:info] [pid 292002:tid ???] [module.go:76] mod_prometheus_status v0.3.0 initialized - socket:/tmp/mtr.1NCGA8 - uid:33 - gid:33 - build:0.3.0
[Tue Nov 07 18:41:46.389452 2023] [mpm_event:notice] [pid 291863:tid 140066010122112] AH00489: Apache/2.4.57 (Ubuntu) configured -- resuming normal operations
[Tue Nov 07 18:41:46.389634 2023] [core:notice] [pid 291863:tid 140066010122112] AH00094: Command line: '/usr/sbin/apache2'
```