### PR TITLE
only chown socket when running as root

### DIFF
--- a/cmd/mod_prometheus_status/module.go
+++ b/cmd/mod_prometheus_status/module.go
@@ -86,11 +86,13 @@ func startMetricServer(startChannel chan bool, socketPath string, userID, groupI
 		return
 	}
 	defer l.Close()
-	err = os.Chown(socketPath, userID, groupID)
-	if err != nil {
-		logErrorf("cannot chown metricssocket: %s", err.Error())
-		startChannel <- false
-		return
+	if os.Geteuid() == 0 {
+		err = os.Chown(socketPath, userID, groupID)
+		if err != nil {
+			logErrorf("cannot chown metricssocket: %s", err.Error())
+			startChannel <- false
+			return
+		}
 	}
 
 	logDebugf("listening on metricsSocket: %s", socketPath)


### PR DESCRIPTION
With this patch module works fine when httpd runs as non-root.

For unpriveleged users chown operation fails (and is not needed ultimately since all child processes are running as same user).